### PR TITLE
updates tests and cv ny config to read from csv instead of h5

### DIFF
--- a/cv/ny.yml
+++ b/cv/ny.yml
@@ -27,7 +27,7 @@ ar:
 sir:
   module: sir
   output: sir_model.npy
-  data: data/nystate/timeseries.h5
+  data: data/nystate/data-new.csv
   train:
     fpop: *fpop
     window: 1

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -3,8 +3,8 @@ import pandas as pd
 import pytest
 
 
-DATA_PATH_CSV = "data/usa/data_cases.csv"
-DATA_PATH_H5 = "data/nystate/timeseries.h5"
+DATA_PATH_US_CSV = "data/usa/data_cases.csv"
+DATA_PATH_NY_CSV = "data/nystate/data-new.csv"
 POP_PATH = "data/population-data/US-states/new-york-population.csv"
 
 
@@ -15,7 +15,7 @@ class TestLoad:
         assert isinstance(df, pd.DataFrame)
         assert df["region"].shape[0] == df["population"].shape[0]
 
-    @pytest.mark.parametrize("path", [DATA_PATH_CSV, DATA_PATH_H5])
+    @pytest.mark.parametrize("path", [DATA_PATH_US_CSV, DATA_PATH_NY_CSV])
     def test_load_cases_by_region(self, path):
         """Confirms cases loaded are per region"""
         cases_df = load.load_confirmed_by_region(path)
@@ -29,13 +29,13 @@ class TestLoad:
 
     def test_regions_match_in_cases_and_population(self):
         """Verifies the regions in cases and population data match"""
-        cases_df = load.load_confirmed_by_region(DATA_PATH_H5)
+        cases_df = load.load_confirmed_by_region(DATA_PATH_NY_CSV)
         populations_df = load.load_populations_by_region(POP_PATH)
         case_regions = sorted(cases_df.columns)
         population_regions = sorted(populations_df["region"].tolist())
         assert case_regions == population_regions
 
-    @pytest.mark.parametrize("path", [DATA_PATH_CSV, DATA_PATH_H5])
+    @pytest.mark.parametrize("path", [DATA_PATH_US_CSV, DATA_PATH_NY_CSV])
     def test_load_confirmed(self, path):
         df = load.load_confirmed(path, None)
         assert df.index.name == "date"

--- a/tests/test_sir.py
+++ b/tests/test_sir.py
@@ -16,7 +16,7 @@ basedir = os.getcwd()
 
 
 class TrainParamsNY:
-    fdat = "data/nystate/timeseries.h5"
+    fdat = "data/nystate/data-new.csv"
     fpop = "data/population-data/US-states/new-york-population.csv"
     window = 14
     recovery_days = 14


### PR DESCRIPTION
**Test Plan**
* removed `timeseries.h5`, regenerated ny data (`make data-ny`), then ran tests (`python -m pytest tests`)