### PR TITLE
Fix population file for NY State

### DIFF
--- a/cv/ny.yml
+++ b/cv/ny.yml
@@ -1,6 +1,5 @@
 region: nystate
-#population: &fpop data/population-data/US-states/new-york-population.csv
-population: &fpop data/usa/population.csv
+population: &fpop data/population-data/US-states/new-york-population.csv
 validation:
   days: 21
   output: validation.csv


### PR DESCRIPTION
`cv/ny.yml` incorrectly set population file to use US population data, which don't have the same region names. This changes the population to the correct NY State population file. 